### PR TITLE
call computeLibraryElement on all libs, not just entry points

### DIFF
--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -21,7 +21,15 @@ abstract class Resolver {
   ///
   /// [release] must be called when done handling this Resolver to allow it
   /// to be used by later phases.
-  Future<Resolver> resolve(Transform transform, [List<AssetId> entryPoints]);
+  ///
+  /// If [resolveAllLibraries] is [false], then transitive imports will not
+  /// be resolved. This will result in faster resolution, but you will need to
+  /// manually call something like
+  /// `libary.context.computeLibraryElement(library.definingCompilationUnit.source);`
+  /// for each [LibraryElement] that you want to ensure is fully resolved. The
+  /// default value is [true].
+  Future<Resolver> resolve(Transform transform,
+      [List<AssetId> entryPoints, bool resolveAllLibraries]);
 
   /// Release this resolver so it can be updated by following transforms.
   void release();

--- a/lib/src/resolver_impl.dart
+++ b/lib/src/resolver_impl.dart
@@ -156,6 +156,14 @@ class ResolverImpl implements Resolver {
         if (source == null) return null;
         return _context.computeLibraryElement(source);
       }).toList();
+
+      // Force resolve all other available libraries. As of analyzer > 0.27.1
+      // this is necessary to get resolved constants.
+      for (var library in libraries) {
+        if (library.source.uri.scheme == 'dart') continue;
+        if (_entryLibraries.contains(library)) continue;
+        _context.computeLibraryElement(library.definingCompilationUnit.source);
+      }
     });
   }
 

--- a/lib/src/resolver_impl.dart
+++ b/lib/src/resolver_impl.dart
@@ -165,12 +165,17 @@ class ResolverImpl implements Resolver {
       if (resolveAllLibraries) {
         // Force resolve all other available libraries. As of analyzer > 0.27.1
         // this is necessary to get resolved constants.
+        var newLibraries = new Set<LibraryElement>();
         for (var library in libraries) {
-          if (library.source.uri.scheme == 'dart') continue;
-          if (_entryLibraries.contains(library)) continue;
-          _context
-              .computeLibraryElement(library.definingCompilationUnit.source);
+          if (library.source.uri.scheme == 'dart' ||
+              _entryLibraries.contains(library)) {
+            newLibraries.add(library);
+          } else {
+            newLibraries.add(_context
+                .computeLibraryElement(library.definingCompilationUnit.source));
+          }
         }
+        _libraries = newLibraries;
       }
     });
   }

--- a/lib/src/resolver_impl.dart
+++ b/lib/src/resolver_impl.dart
@@ -71,14 +71,17 @@ class ResolverImpl implements Resolver {
     return source == null ? null : _context.computeLibraryElement(source);
   }
 
-  Future<Resolver> resolve(Transform transform, [List<AssetId> entryPoints]) {
+  Future<Resolver> resolve(Transform transform,
+      [List<AssetId> entryPoints, bool resolveAllLibraries]) {
     // Can only have one resolve in progress at a time, so chain the current
     // resolution to be after the last one.
     var phaseComplete = new Completer();
     var future = _lastPhaseComplete.whenComplete(() {
       _currentPhaseComplete = phaseComplete;
-      return _performResolve(transform,
-          entryPoints == null ? [transform.primaryInput.id] : entryPoints);
+      return _performResolve(
+          transform,
+          entryPoints == null ? [transform.primaryInput.id] : entryPoints,
+          resolveAllLibraries);
     }).then((_) => this);
     // Advance the lastPhaseComplete to be done when this phase is all done.
     _lastPhaseComplete = phaseComplete.future;
@@ -98,7 +101,9 @@ class ResolverImpl implements Resolver {
     _currentTransform = null;
   }
 
-  Future _performResolve(Transform transform, List<AssetId> entryPoints) {
+  Future _performResolve(Transform transform, List<AssetId> entryPoints,
+      bool resolveAllLibraries) {
+    resolveAllLibraries ??= true;
     if (_currentTransform != null) {
       throw new StateError('Cannot be accessed by concurrent transforms');
     }
@@ -157,12 +162,15 @@ class ResolverImpl implements Resolver {
         return _context.computeLibraryElement(source);
       }).toList();
 
-      // Force resolve all other available libraries. As of analyzer > 0.27.1
-      // this is necessary to get resolved constants.
-      for (var library in libraries) {
-        if (library.source.uri.scheme == 'dart') continue;
-        if (_entryLibraries.contains(library)) continue;
-        _context.computeLibraryElement(library.definingCompilationUnit.source);
+      if (resolveAllLibraries) {
+        // Force resolve all other available libraries. As of analyzer > 0.27.1
+        // this is necessary to get resolved constants.
+        for (var library in libraries) {
+          if (library.source.uri.scheme == 'dart') continue;
+          if (_entryLibraries.contains(library)) continue;
+          _context
+              .computeLibraryElement(library.definingCompilationUnit.source);
+        }
       }
     });
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/dart-lang/code-transformers
 environment:
   sdk: '>=1.0.0 <2.0.0'
 dependencies:
-  analyzer: '>=0.27.0 <0.28.0'
+  analyzer: '>=0.27.2 <0.28.0'
   barback: '>=0.14.2 <0.16.0'
   cli_util: '>=0.0.1 <0.1.0'
   path: '>=0.9.0 <2.0.0'

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -257,6 +257,28 @@ resolverTests(Resolvers resolvers) {
       });
     });
 
+    test('should resolve constants in transitive imports', () {
+      return validateResolver(inputs: {
+        'a|web/main.dart': '''
+              library web.main;
+
+              import 'package:a/a.dart';
+              class Foo extends Bar {}
+              ''',
+        'a|lib/a.dart': '''
+              library a.a;
+
+              const int annotation = 0;
+              @annotation
+              class Bar {}''',
+      }, validator: (Resolver resolver) {
+        var main = resolver.getLibraryByName('web.main');
+        var meta = main.unit.declarations[0].element.supertype.element.metadata[0];
+        expect(meta, isNotNull);
+        expect(meta.constantValue, 0);
+      });
+    });
+
     test('deleted files should be removed', () {
       return validateResolver(
           inputs: {

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -263,6 +263,8 @@ resolverTests(Resolvers resolvers) {
               library web.main;
 
               import 'package:a/a.dart';
+              export 'package:a/a.dart';
+
               class Foo extends Bar {}
               ''',
         'a|lib/a.dart': '''
@@ -271,11 +273,12 @@ resolverTests(Resolvers resolvers) {
               const int annotation = 0;
               @annotation
               class Bar {}''',
-      }, validator: (Resolver resolver) {
+      }, validator: (resolver) {
         var main = resolver.getLibraryByName('web.main');
-        var meta = main.unit.declarations[0].element.supertype.element.metadata[0];
+        var meta =
+            main.unit.declarations[0].element.supertype.element.metadata[0];
         expect(meta, isNotNull);
-        expect(meta.constantValue, 0);
+        expect(meta.constantValue, isNotNull);
       });
     });
 

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -299,14 +299,23 @@ resolverTests(Resolvers resolvers) {
               class Foo extends Bar {}
               ''',
             'a|lib/do_resolve.dart': '''
+              library a.do_resolve;
+
               const int annotation = 0;
               @annotation
               class Bar {}''',
           },
           validator: (resolver) {
             var main = resolver.getLibraryByName('web.main');
+            // Navigate to the library via Element models
             var meta =
                 main.unit.declarations[0].element.supertype.element.metadata[0];
+            expect(meta, isNotNull);
+            expect(meta.constantValue, isNotNull);
+
+            // Get the library from the resolver directly
+            var lib = resolver.getLibraryByName('a.do_resolve');
+            meta = lib.unit.declarations[1].element.metadata[0];
             expect(meta, isNotNull);
             expect(meta.constantValue, isNotNull);
           });

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -31,235 +31,266 @@ main() {
 
 resolverTests(Resolvers resolvers) {
   var entryPoint = new AssetId('a', 'web/main.dart');
-  Future validateResolver({Map<String, String> inputs, validator(Resolver),
-      List<String> messages: const [], bool resolveAllLibraries: true}) {
-    return applyTransformers(
-        [[new TestTransformer(resolvers, entryPoint, validator, resolveAllLibraries)]],
-        inputs: inputs, messages: messages);
+  Future validateResolver(
+      {Map<String, String> inputs,
+      validator(Resolver),
+      List<String> messages: const [],
+      bool resolveAllLibraries: true}) {
+    return applyTransformers([
+      [
+        new TestTransformer(
+            resolvers, entryPoint, validator, resolveAllLibraries)
+      ]
+    ], inputs: inputs, messages: messages);
   }
 
   group('Resolver', () {
     test('should handle initial files', () {
       return validateResolver(
-          inputs: {'a|web/main.dart': ' main() {}',}, validator: (resolver) {
-        var source = resolver.sources[entryPoint];
-        expect(source.modificationStamp, 1);
+          inputs: {'a|web/main.dart': ' main() {}',},
+          validator: (resolver) {
+            var source = resolver.sources[entryPoint];
+            expect(source.modificationStamp, 1);
 
-        var lib = resolver.getLibrary(entryPoint);
-        expect(lib, isNotNull);
-      });
+            var lib = resolver.getLibrary(entryPoint);
+            expect(lib, isNotNull);
+          });
     });
 
     test('should update when sources change', () {
-      return validateResolver(inputs: {
-        'a|web/main.dart': ''' main() {
+      return validateResolver(
+          inputs: {
+            'a|web/main.dart': ''' main() {
                 } ''',
-      }, validator: (resolver) {
-        var source = resolver.sources[entryPoint];
-        expect(source.modificationStamp, 2);
+          },
+          validator: (resolver) {
+            var source = resolver.sources[entryPoint];
+            expect(source.modificationStamp, 2);
 
-        var lib = resolver.getLibrary(entryPoint);
-        expect(lib, isNotNull);
-        expect(lib.entryPoint, isNotNull);
-      });
+            var lib = resolver.getLibrary(entryPoint);
+            expect(lib, isNotNull);
+            expect(lib.entryPoint, isNotNull);
+          });
     });
 
     test('should follow imports', () {
-      return validateResolver(inputs: {
-        'a|web/main.dart': '''
+      return validateResolver(
+          inputs: {
+            'a|web/main.dart': '''
               import 'a.dart';
 
               main() {
               } ''',
-        'a|web/a.dart': '''
+            'a|web/a.dart': '''
               library a;
               ''',
-      }, validator: (resolver) {
-        var lib = resolver.getLibrary(entryPoint);
-        expect(lib.importedLibraries.length, 2);
-        var libA = lib.importedLibraries.where((l) => l.name == 'a').single;
-        expect(libA.getType('Foo'), isNull);
-      });
+          },
+          validator: (resolver) {
+            var lib = resolver.getLibrary(entryPoint);
+            expect(lib.importedLibraries.length, 2);
+            var libA = lib.importedLibraries.where((l) => l.name == 'a').single;
+            expect(libA.getType('Foo'), isNull);
+          });
     });
 
     test('should update changed imports', () {
-      return validateResolver(inputs: {
-        'a|web/main.dart': '''
+      return validateResolver(
+          inputs: {
+            'a|web/main.dart': '''
               import 'a.dart';
 
               main() {
               } ''',
-        'a|web/a.dart': '''
+            'a|web/a.dart': '''
               library a;
               class Foo {}
               ''',
-      }, validator: (resolver) {
-        var lib = resolver.getLibrary(entryPoint);
-        expect(lib.importedLibraries.length, 2);
-        var libA = lib.importedLibraries.where((l) => l.name == 'a').single;
-        expect(libA.getType('Foo'), isNotNull);
-      });
+          },
+          validator: (resolver) {
+            var lib = resolver.getLibrary(entryPoint);
+            expect(lib.importedLibraries.length, 2);
+            var libA = lib.importedLibraries.where((l) => l.name == 'a').single;
+            expect(libA.getType('Foo'), isNotNull);
+          });
     });
 
     test('should follow package imports', () {
-      return validateResolver(inputs: {
-        'a|web/main.dart': '''
+      return validateResolver(
+          inputs: {
+            'a|web/main.dart': '''
               import 'package:b/b.dart';
 
               main() {
               } ''',
-        'b|lib/b.dart': '''
+            'b|lib/b.dart': '''
               library b;
               ''',
-      }, validator: (resolver) {
-        var lib = resolver.getLibrary(entryPoint);
-        expect(lib.importedLibraries.length, 2);
-        var libB = lib.importedLibraries.where((l) => l.name == 'b').single;
-        expect(libB.getType('Foo'), isNull);
-      });
+          },
+          validator: (resolver) {
+            var lib = resolver.getLibrary(entryPoint);
+            expect(lib.importedLibraries.length, 2);
+            var libB = lib.importedLibraries.where((l) => l.name == 'b').single;
+            expect(libB.getType('Foo'), isNull);
+          });
     });
 
     test('handles missing files', () {
-      return validateResolver(inputs: {
-        'a|web/main.dart': '''
+      return validateResolver(
+          inputs: {
+            'a|web/main.dart': '''
               import 'package:b/missing.dart';
 
               main() {
               } ''',
-      }, validator: (resolver) {
-        var lib = resolver.getLibrary(entryPoint);
-        expect(lib.importedLibraries.length, 1);
-      });
+          },
+          validator: (resolver) {
+            var lib = resolver.getLibrary(entryPoint);
+            expect(lib.importedLibraries.length, 1);
+          });
     });
 
     test('should update on changed package imports', () {
       // TODO(sigmund): remove modification below, see dartbug.com/22638
-      return validateResolver(inputs: {
-        'a|web/main.dart': '''
+      return validateResolver(
+          inputs: {
+            'a|web/main.dart': '''
               import 'package:b/missing.dart';
 
               main() {
               } // modified, but we shouldn't need to! ''',
-        'b|lib/missing.dart': '''
+            'b|lib/missing.dart': '''
               library b;
               class Bar {}
               ''',
-      }, validator: (resolver) {
-        var lib = resolver.getLibrary(entryPoint);
-        expect(lib.importedLibraries.length, 2);
-        var libB = lib.importedLibraries.where((l) => l.name == 'b').single;
-        expect(libB.getType('Bar'), isNotNull);
-      });
+          },
+          validator: (resolver) {
+            var lib = resolver.getLibrary(entryPoint);
+            expect(lib.importedLibraries.length, 2);
+            var libB = lib.importedLibraries.where((l) => l.name == 'b').single;
+            expect(libB.getType('Bar'), isNotNull);
+          });
     });
 
     test('should handle deleted files', () {
-      return validateResolver(inputs: {
-        'a|web/main.dart': '''
+      return validateResolver(
+          inputs: {
+            'a|web/main.dart': '''
               import 'package:b/missing.dart';
 
               main() {
               } ''',
-      }, validator: (resolver) {
-        var lib = resolver.getLibrary(entryPoint);
-        expect(lib.importedLibraries.length, 1);
-      });
+          },
+          validator: (resolver) {
+            var lib = resolver.getLibrary(entryPoint);
+            expect(lib.importedLibraries.length, 1);
+          });
     });
 
     test('should fail on absolute URIs', () {
       var warningPrefix = 'warning: absolute paths not allowed';
-      return validateResolver(inputs: {
-        'a|web/main.dart': '''
+      return validateResolver(
+          inputs: {
+            'a|web/main.dart': '''
               import '/b.dart';
 
               main() {
               } ''',
-      }, messages: [
-        // First from the AST walker
-        '$warningPrefix: "/b.dart" (web/main.dart 0 14)',
-        '$warningPrefix: "/b.dart"',
-      ], validator: (resolver) {
-        var lib = resolver.getLibrary(entryPoint);
-        expect(lib.importedLibraries.length, 1);
-      });
+          },
+          messages: [
+            // First from the AST walker
+            '$warningPrefix: "/b.dart" (web/main.dart 0 14)',
+            '$warningPrefix: "/b.dart"',
+          ],
+          validator: (resolver) {
+            var lib = resolver.getLibrary(entryPoint);
+            expect(lib.importedLibraries.length, 1);
+          });
     });
 
     test('should list all libraries', () {
-      return validateResolver(inputs: {
-        'a|web/main.dart': '''
+      return validateResolver(
+          inputs: {
+            'a|web/main.dart': '''
               library a.main;
               import 'package:a/a.dart';
               import 'package:a/b.dart';
               export 'package:a/d.dart';
               ''',
-        'a|lib/a.dart': 'library a.a;\n import "package:a/c.dart";',
-        'a|lib/b.dart': 'library a.b;\n import "c.dart";',
-        'a|lib/c.dart': 'library a.c;',
-        'a|lib/d.dart': 'library a.d;'
-      }, validator: (resolver) {
-        var libs = resolver.libraries.where((l) => !l.isInSdk);
-        expect(libs.map((l) => l.name),
-            unorderedEquals(['a.main', 'a.a', 'a.b', 'a.c', 'a.d',]));
-      });
+            'a|lib/a.dart': 'library a.a;\n import "package:a/c.dart";',
+            'a|lib/b.dart': 'library a.b;\n import "c.dart";',
+            'a|lib/c.dart': 'library a.c;',
+            'a|lib/d.dart': 'library a.d;'
+          },
+          validator: (resolver) {
+            var libs = resolver.libraries.where((l) => !l.isInSdk);
+            expect(libs.map((l) => l.name),
+                unorderedEquals(['a.main', 'a.a', 'a.b', 'a.c', 'a.d',]));
+          });
     });
 
     test('should resolve types and library uris', () {
-      return validateResolver(inputs: {
-        'a|web/main.dart': '''
+      return validateResolver(
+          inputs: {
+            'a|web/main.dart': '''
               import 'dart:core';
               import 'package:a/a.dart';
               import 'package:a/b.dart';
               import 'sub_dir/d.dart';
               class Foo {}
               ''',
-        'a|lib/a.dart': 'library a.a;\n import "package:a/c.dart";',
-        'a|lib/b.dart': 'library a.b;\n import "c.dart";',
-        'a|lib/c.dart': '''
+            'a|lib/a.dart': 'library a.a;\n import "package:a/c.dart";',
+            'a|lib/b.dart': 'library a.b;\n import "c.dart";',
+            'a|lib/c.dart': '''
                 library a.c;
                 class Bar {}
                 ''',
-        'a|web/sub_dir/d.dart': '''
+            'a|web/sub_dir/d.dart': '''
                 library a.web.sub_dir.d;
                 class Baz{}
                 ''',
-      }, validator: (resolver) {
-        var a = resolver.getLibraryByName('a.a');
-        expect(a, isNotNull);
-        expect(resolver.getImportUri(a).toString(), 'package:a/a.dart');
-        expect(resolver.getLibraryByUri(Uri.parse('package:a/a.dart')), a);
+          },
+          validator: (resolver) {
+            var a = resolver.getLibraryByName('a.a');
+            expect(a, isNotNull);
+            expect(resolver.getImportUri(a).toString(), 'package:a/a.dart');
+            expect(resolver.getLibraryByUri(Uri.parse('package:a/a.dart')), a);
 
-        var main = resolver.getLibraryByName('');
-        expect(main, isNotNull);
-        expect(resolver.getImportUri(main), isNull);
+            var main = resolver.getLibraryByName('');
+            expect(main, isNotNull);
+            expect(resolver.getImportUri(main), isNull);
 
-        var fooType = resolver.getType('Foo');
-        expect(fooType, isNotNull);
-        expect(fooType.library, main);
+            var fooType = resolver.getType('Foo');
+            expect(fooType, isNotNull);
+            expect(fooType.library, main);
 
-        var barType = resolver.getType('a.c.Bar');
-        expect(barType, isNotNull);
-        expect(resolver.getImportUri(barType.library).toString(),
-            'package:a/c.dart');
-        expect(
-            resolver.getSourceAssetId(barType), new AssetId('a', 'lib/c.dart'));
+            var barType = resolver.getType('a.c.Bar');
+            expect(barType, isNotNull);
+            expect(resolver.getImportUri(barType.library).toString(),
+                'package:a/c.dart');
+            expect(resolver.getSourceAssetId(barType),
+                new AssetId('a', 'lib/c.dart'));
 
-        var bazType = resolver.getType('a.web.sub_dir.d.Baz');
-        expect(bazType, isNotNull);
-        expect(resolver.getImportUri(bazType.library), isNull);
-        expect(
-            resolver.getImportUri(bazType.library, from: entryPoint).toString(),
-            'sub_dir/d.dart');
+            var bazType = resolver.getType('a.web.sub_dir.d.Baz');
+            expect(bazType, isNotNull);
+            expect(resolver.getImportUri(bazType.library), isNull);
+            expect(
+                resolver
+                    .getImportUri(bazType.library, from: entryPoint)
+                    .toString(),
+                'sub_dir/d.dart');
 
-        var hashMap = resolver.getType('dart.collection.HashMap');
-        expect(resolver.getImportUri(hashMap.library).toString(),
-            'dart:collection');
-        expect(resolver.getLibraryByUri(Uri.parse('dart:collection')),
-            hashMap.library);
-      });
+            var hashMap = resolver.getType('dart.collection.HashMap');
+            expect(resolver.getImportUri(hashMap.library).toString(),
+                'dart:collection');
+            expect(resolver.getLibraryByUri(Uri.parse('dart:collection')),
+                hashMap.library);
+          });
     });
 
     test('should resolve constants in transitive imports by default', () {
-      return validateResolver(inputs: {
-        'a|web/main.dart': '''
+      return validateResolver(
+          inputs: {
+            'a|web/main.dart': '''
               library web.main;
 
               import 'package:a/do_resolve.dart';
@@ -267,22 +298,25 @@ resolverTests(Resolvers resolvers) {
 
               class Foo extends Bar {}
               ''',
-        'a|lib/do_resolve.dart': '''
+            'a|lib/do_resolve.dart': '''
               const int annotation = 0;
               @annotation
               class Bar {}''',
-      }, validator: (resolver) {
-        var main = resolver.getLibraryByName('web.main');
-        var meta =
-            main.unit.declarations[0].element.supertype.element.metadata[0];
-        expect(meta, isNotNull);
-        expect(meta.constantValue, isNotNull);
-      });
+          },
+          validator: (resolver) {
+            var main = resolver.getLibraryByName('web.main');
+            var meta =
+                main.unit.declarations[0].element.supertype.element.metadata[0];
+            expect(meta, isNotNull);
+            expect(meta.constantValue, isNotNull);
+          });
     });
 
     test('can disable resolving of constants in transitive imports', () {
-      return validateResolver(resolveAllLibraries: false, inputs: {
-        'a|web/main.dart': '''
+      return validateResolver(
+          resolveAllLibraries: false,
+          inputs: {
+            'a|web/main.dart': '''
               library web.main;
 
               import 'package:a/dont_resolve.dart';
@@ -290,81 +324,88 @@ resolverTests(Resolvers resolvers) {
 
               class Foo extends Bar {}
               ''',
-        'a|lib/dont_resolve.dart': '''
+            'a|lib/dont_resolve.dart': '''
               library a.dont_resolve;
 
               const int annotation = 0;
               @annotation
               class Bar {}''',
-      }, validator: (resolver) {
-        var main = resolver.getLibraryByName('web.main');
-        var meta =
-            main.unit.declarations[0].element.supertype.element.metadata[0];
-        expect(meta, isNotNull);
-        expect(meta.constantValue, isNull);
-      });
+          },
+          validator: (resolver) {
+            var main = resolver.getLibraryByName('web.main');
+            var meta =
+                main.unit.declarations[0].element.supertype.element.metadata[0];
+            expect(meta, isNotNull);
+            expect(meta.constantValue, isNull);
+          });
     });
 
     test('deleted files should be removed', () {
       return validateResolver(
           inputs: {
-        'a|web/main.dart': '''import 'package:a/a.dart';''',
-        'a|lib/a.dart': '''import 'package:a/b.dart';''',
-        'a|lib/b.dart': '''class Engine{}''',
-      },
+            'a|web/main.dart': '''import 'package:a/a.dart';''',
+            'a|lib/a.dart': '''import 'package:a/b.dart';''',
+            'a|lib/b.dart': '''class Engine{}''',
+          },
           validator: (resolver) {
-        var engine = resolver.getType('Engine');
-        var uri = resolver.getImportUri(engine.library);
-        expect(uri.toString(), 'package:a/b.dart');
-      }).then((_) {
+            var engine = resolver.getType('Engine');
+            var uri = resolver.getImportUri(engine.library);
+            expect(uri.toString(), 'package:a/b.dart');
+          }).then((_) {
         return validateResolver(
             inputs: {
-          'a|web/main.dart': '''import 'package:a/a.dart';''',
-          'a|lib/a.dart': '''lib a;\n class Engine{}'''
-        },
+              'a|web/main.dart': '''import 'package:a/a.dart';''',
+              'a|lib/a.dart': '''lib a;\n class Engine{}'''
+            },
             validator: (resolver) {
-          var engine = resolver.getType('Engine');
-          var uri = resolver.getImportUri(engine.library);
-          expect(uri.toString(), 'package:a/a.dart');
+              var engine = resolver.getType('Engine');
+              var uri = resolver.getImportUri(engine.library);
+              expect(uri.toString(), 'package:a/a.dart');
 
-          // Make sure that we haven't leaked any sources.
-          expect(resolver.sources.length, 2);
-        });
+              // Make sure that we haven't leaked any sources.
+              expect(resolver.sources.length, 2);
+            });
       });
     });
 
     test('handles circular imports', () {
-      return validateResolver(inputs: {
-        'a|web/main.dart': '''
+      return validateResolver(
+          inputs: {
+            'a|web/main.dart': '''
                 library main;
                 import 'package:a/a.dart'; ''',
-        'a|lib/a.dart': '''
+            'a|lib/a.dart': '''
                 library a;
                 import 'package:a/b.dart'; ''',
-        'a|lib/b.dart': '''
+            'a|lib/b.dart': '''
                 library b;
                 import 'package:a/a.dart'; ''',
-      }, validator: (resolver) {
-        var libs = resolver.libraries.map((lib) => lib.name);
-        expect(libs.contains('a'), isTrue);
-        expect(libs.contains('b'), isTrue);
-      });
+          },
+          validator: (resolver) {
+            var libs = resolver.libraries.map((lib) => lib.name);
+            expect(libs.contains('a'), isTrue);
+            expect(libs.contains('b'), isTrue);
+          });
     });
 
     test('handles parallel resolves', () {
       return Future.wait([
-        validateResolver(inputs: {
-          'a|web/main.dart': '''
+        validateResolver(
+            inputs: {
+              'a|web/main.dart': '''
                 library foo;'''
-        }, validator: (resolver) {
-          expect(resolver.getLibrary(entryPoint).name, 'foo');
-        }),
-        validateResolver(inputs: {
-          'a|web/main.dart': '''
+            },
+            validator: (resolver) {
+              expect(resolver.getLibrary(entryPoint).name, 'foo');
+            }),
+        validateResolver(
+            inputs: {
+              'a|web/main.dart': '''
                 library bar;'''
-        }, validator: (resolver) {
-          expect(resolver.getLibrary(entryPoint).name, 'bar');
-        }),
+            },
+            validator: (resolver) {
+              expect(resolver.getLibrary(entryPoint).name, 'bar');
+            }),
       ]);
     });
   });
@@ -375,9 +416,8 @@ class TestTransformer extends Transformer with ResolverTransformer {
   final Function validator;
   final bool resolveAllLibraries;
 
-  TestTransformer(
-    Resolvers resolvers, this.primary, this.validator,
-    this.resolveAllLibraries) {
+  TestTransformer(Resolvers resolvers, this.primary, this.validator,
+      this.resolveAllLibraries) {
     this.resolvers = resolvers;
   }
 


### PR DESCRIPTION
cc @eernstg @sigmundch 

This should resolve the issues that reflectable has been seeing, as well as a few other packages.

An alternative solution to this would be to expose a way of computing individual libraries, but for all current use cases that I know of (reflectable, initialize) this would need to be done for every library anyways :(.

From some really preliminary experiments this significantly increases overall resolve time (highly dependent on app size). However, I don't think it can really be avoided.

See https://github.com/dart-lang/sdk/issues/24890 for more info.
