### PR TITLE
use a single Resolver instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
+## 0.5.0
+
+* Always use a single `Resolver` instance. Fixes an issue where running with the
+  'build' package in file watching mode would treat some files as never
+  changing.
+* Breaking Change: remove the `useSharedSources` argument to Resolvers ctor
+  since sources are always shared.
+
 ## 0.4.2+3
+
 * Update to work with analyzer 0.28.x.
 
 ## 0.4.2+2

--- a/lib/src/resolver_impl.dart
+++ b/lib/src/resolver_impl.dart
@@ -31,7 +31,7 @@ final path = native_path.url;
 /// with the resolved AST.
 class ResolverImpl implements Resolver {
   /// Cache of all asset sources currently referenced.
-  final Map<AssetId, AssetBasedSource> sources;
+  final Map<AssetId, AssetBasedSource> sources = {};
 
   final InternalAnalysisContext _context =
       AnalysisEngine.instance.createAnalysisContext();
@@ -49,15 +49,10 @@ class ResolverImpl implements Resolver {
   /// Completer for wrapping up the current phase.
   Completer _currentPhaseComplete;
 
-  /// Whether or not we are using a shared sources cache.
-  final bool _usingSharedSources;
-
   /// Creates a resolver with a given [sdk] implementation for resolving
   /// `dart:*` imports.
   ResolverImpl(DartSdk sdk, DartUriResolver dartUriResolver,
-      {AnalysisOptions options, Map<AssetId, AssetBasedSource> sources})
-      : _usingSharedSources = sources != null,
-        sources = sources ?? <AssetId, AssetBasedSource>{} {
+      {AnalysisOptions options, Map<AssetId, AssetBasedSource> sources}) {
     if (options == null) {
       options = new AnalysisOptionsImpl()
         ..cacheSize = 256 // # of sources to cache ASTs for.
@@ -140,6 +135,7 @@ class ResolverImpl implements Resolver {
         }
       }));
     }
+
     entryPoints.forEach(processAsset);
 
     // Once we have all asset sources updated with the new contents then
@@ -147,18 +143,6 @@ class ResolverImpl implements Resolver {
     return visiting.future.then((_) {
       var changeSet = new ChangeSet();
       toUpdate.forEach((pending) => pending.apply(changeSet));
-
-      // If we aren't using shared sources, then remove from the cache any
-      // sources which are no longer reachable.
-      if (!_usingSharedSources) {
-        var unreachableAssets =
-            sources.keys.toSet().difference(visited).map((id) => sources[id]);
-        for (var unreachable in unreachableAssets) {
-          changeSet.removedSource(unreachable);
-          unreachable.updateContents(null);
-          sources.remove(unreachable.assetId);
-        }
-      }
 
       // Update the analyzer context with the latest sources
       _context.applyChanges(changeSet);

--- a/lib/src/resolver_impl.dart
+++ b/lib/src/resolver_impl.dart
@@ -52,7 +52,7 @@ class ResolverImpl implements Resolver {
   /// Creates a resolver with a given [sdk] implementation for resolving
   /// `dart:*` imports.
   ResolverImpl(DartSdk sdk, DartUriResolver dartUriResolver,
-      {AnalysisOptions options, Map<AssetId, AssetBasedSource> sources}) {
+      {AnalysisOptions options}) {
     if (options == null) {
       options = new AnalysisOptionsImpl()
         ..cacheSize = 256 // # of sources to cache ASTs for.

--- a/lib/src/resolvers.dart
+++ b/lib/src/resolvers.dart
@@ -64,9 +64,8 @@ class Resolvers {
   ///
   /// See [Resolver#resolve] for more info on the `resolveAllLibraries` option.
   Future<Resolver> get(Transform transform,
-      [List<AssetId> entryPoints, bool resolveAllLibraries]) {
-    return _resolver.resolve(transform, entryPoints, resolveAllLibraries);
-  }
+          [List<AssetId> entryPoints, bool resolveAllLibraries]) =>
+      _resolver.resolve(transform, entryPoints, resolveAllLibraries);
 }
 
 /// Transformer mixin which automatically gets and releases resolvers.

--- a/lib/src/resolvers.dart
+++ b/lib/src/resolvers.dart
@@ -27,22 +27,11 @@ import 'dart_sdk.dart' hide dartSdkDirectory;
 /// If multiple transformers rely on a resolved AST they should (ideally) share
 /// the same Resolvers object to minimize re-parsing the AST.
 class Resolvers {
-  final Map<AssetId, Resolver> _resolvers = {};
-  final DartSdk dartSdk;
-  final DartUriResolver dartUriResolver;
-  final AnalysisOptions options;
+  final Resolver _resolver;
 
-  /// Null unless `useSharedSources` is true. This option should only be used if
-  /// you know that files are always in a consistent state wherever this
-  /// resolvers object is used. Any time that [Resolvers#get] or
-  /// [Resolver#resolve] are called it will update the sources globally when
-  /// this option is in use.
-  final Map<AssetId, AssetBasedSource> sharedSources;
-
-  Resolvers.fromSdk(this.dartSdk, this.dartUriResolver,
-      {this.options, bool useSharedSources})
-      : sharedSources =
-            useSharedSources == true ? <AssetId, AssetBasedSource>{} : null;
+  Resolvers.fromSdk(DartSdk dartSdk, DartUriResolver dartUriResolver,
+      {AnalysisOptions options, bool useSharedSources}) :
+  _resolver = new ResolverImpl(dartSdk, dartUriResolver, options: options);
 
   factory Resolvers(String dartSdkDirectory,
       {AnalysisOptions options, bool useSharedSources}) {
@@ -75,12 +64,7 @@ class Resolvers {
   /// See [Resolver#resolve] for more info on the `resolveAllLibraries` option.
   Future<Resolver> get(Transform transform,
       [List<AssetId> entryPoints, bool resolveAllLibraries]) {
-    var id = transform.primaryInput.id;
-    var resolver = _resolvers.putIfAbsent(
-        id,
-        () => new ResolverImpl(dartSdk, dartUriResolver,
-            options: options, sources: sharedSources));
-    return resolver.resolve(transform, entryPoints, resolveAllLibraries);
+    return _resolver.resolve(transform, entryPoints, resolveAllLibraries);
   }
 }
 

--- a/lib/src/resolvers.dart
+++ b/lib/src/resolvers.dart
@@ -30,28 +30,23 @@ class Resolvers {
   final Resolver _resolver;
 
   Resolvers.fromSdk(DartSdk dartSdk, DartUriResolver dartUriResolver,
-      {AnalysisOptions options, bool useSharedSources})
-      : _resolver = new ResolverImpl(dartSdk, dartUriResolver,
-            options: options, sources: {});
+      {AnalysisOptions options})
+      : _resolver =
+            new ResolverImpl(dartSdk, dartUriResolver, options: options);
 
-  factory Resolvers(String dartSdkDirectory,
-      {AnalysisOptions options, bool useSharedSources}) {
+  factory Resolvers(String dartSdkDirectory, {AnalysisOptions options}) {
     _initAnalysisEngine();
     var sdk = new FolderBasedDartSdkProxy(
         PhysicalResourceProvider.INSTANCE, dartSdkDirectory);
     var uriResolver = new DartUriResolverProxy(sdk);
-    return new Resolvers.fromSdk(sdk, uriResolver,
-        options: options, useSharedSources: useSharedSources);
+    return new Resolvers.fromSdk(sdk, uriResolver, options: options);
   }
 
   factory Resolvers.fromMock(Map<String, String> sources,
-      {bool reportMissing: false,
-      AnalysisOptions options,
-      bool useSharedSources}) {
+      {bool reportMissing: false, AnalysisOptions options}) {
     _initAnalysisEngine();
     var sdk = new MockDartSdk(sources, options, reportMissing: reportMissing);
-    return new Resolvers.fromSdk(sdk, sdk.resolver,
-        options: options, useSharedSources: useSharedSources);
+    return new Resolvers.fromSdk(sdk, sdk.resolver, options: options);
   }
 
   /// Get a resolver for [transform]. If provided, this resolves the code

--- a/lib/src/resolvers.dart
+++ b/lib/src/resolvers.dart
@@ -30,8 +30,9 @@ class Resolvers {
   final Resolver _resolver;
 
   Resolvers.fromSdk(DartSdk dartSdk, DartUriResolver dartUriResolver,
-      {AnalysisOptions options, bool useSharedSources}) :
-  _resolver = new ResolverImpl(dartSdk, dartUriResolver, options: options);
+      {AnalysisOptions options, bool useSharedSources})
+      : _resolver = new ResolverImpl(dartSdk, dartUriResolver,
+            options: options, sources: {});
 
   factory Resolvers(String dartSdkDirectory,
       {AnalysisOptions options, bool useSharedSources}) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_transformers
-version: 0.4.2+3
+version: 0.5.0
 author: Dart Team <misc@dartlang.org>
 description: Collection of utilities related to creating barback transformers.
 homepage: https://github.com/dart-lang/code-transformers

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -24,8 +24,7 @@ main() {
   });
 
   group('shared sources', () {
-    resolverTests(
-        new Resolvers.fromMock(mockSdkSources, useSharedSources: true));
+    resolverTests(new Resolvers.fromMock(mockSdkSources));
   });
 }
 
@@ -47,7 +46,9 @@ resolverTests(Resolvers resolvers) {
   group('Resolver', () {
     test('should handle initial files', () {
       return validateResolver(
-          inputs: {'a|web/main.dart': ' main() {}',},
+          inputs: {
+            'a|web/main.dart': ' main() {}',
+          },
           validator: (resolver) {
             var source = resolver.sources[entryPoint];
             expect(source.modificationStamp, 1);
@@ -223,8 +224,15 @@ resolverTests(Resolvers resolvers) {
           },
           validator: (resolver) {
             var libs = resolver.libraries.where((l) => !l.isInSdk);
-            expect(libs.map((l) => l.name),
-                unorderedEquals(['a.main', 'a.a', 'a.b', 'a.c', 'a.d',]));
+            expect(
+                libs.map((l) => l.name),
+                unorderedEquals([
+                  'a.main',
+                  'a.a',
+                  'a.b',
+                  'a.c',
+                  'a.d',
+                ]));
           });
     });
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/119

The Resolver class should be safe to reuse for multiple Transformer instances, the `resolve` method appends to the assets that are resolved and avoids re-entry in the middle of resolving.
