### PR TITLE
Avoid LibraryElement instances for part files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.0+2
+
+* Resolver no longer returns a partial LibraryElement for assets which are no
+  libraries
+
 ## 0.5.0+1
 
 * Stop using deprecated analyzer apis.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.5.0+2
 
-* Resolver no longer returns a partial LibraryElement for assets which are no
+* Resolver no longer returns a partial LibraryElement for assets which are not
   libraries
 
 ## 0.5.0+1

--- a/lib/src/resolver_impl.dart
+++ b/lib/src/resolver_impl.dart
@@ -65,7 +65,10 @@ class ResolverImpl implements Resolver {
 
   LibraryElement getLibrary(AssetId assetId) {
     var source = sources[assetId];
-    return source == null ? null : _context.computeLibraryElement(source);
+    if (source == null) return null;
+    var kind = _context.computeKindOf(source);
+    if (kind != SourceKind.LIBRARY) return null;
+    return _context.computeLibraryElement(source);
   }
 
   Future<Resolver> resolve(Transform transform,
@@ -150,6 +153,8 @@ class ResolverImpl implements Resolver {
       _entryLibraries = entryPoints.map((id) {
         var source = sources[id];
         if (source == null) return null;
+        var kind = _context.computeKindOf(source);
+        if (kind != SourceKind.LIBRARY) return null;
         return _context.computeLibraryElement(source);
       }).toList();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_transformers
-version: 0.5.0+1
+version: 0.5.0+2
 author: Dart Team <misc@dartlang.org>
 description: Collection of utilities related to creating barback transformers.
 homepage: https://github.com/dart-lang/code-transformers


### PR DESCRIPTION
If we pass a Source representing a 'part of' file to the analysis
context it will create a LibraryElement which is not sensible. We should
only create a LibraryElement when the Source represents a library.

Fixes https://github.com/dart-lang/source_gen/issues/115