### PR TITLE
Add a method to check whether an Asset is a libary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.1
+
+* Resolver has a new method which can check whether an Asset is a Dart library
+  source
+
 ## 0.5.0+2
 
 * Resolver no longer returns a partial LibraryElement for assets which are not

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -34,6 +34,12 @@ abstract class Resolver {
   /// Release this resolver so it can be updated by following transforms.
   void release();
 
+  /// Whether [assetId] represents an Dart library file.
+  ///
+  /// This will be false in the case where the file is not Dart source code, or
+  /// is a 'part of' file.
+  bool isLibrary(AssetId assetId);
+
   /// Gets the resolved Dart library for an asset, or null if the AST has not
   /// been resolved.
   ///

--- a/lib/src/resolver_impl.dart
+++ b/lib/src/resolver_impl.dart
@@ -63,11 +63,20 @@ class ResolverImpl implements Resolver {
         new SourceFactory([dartUriResolver, new _AssetUriResolver(this)]);
   }
 
+  @override
+  bool isLibrary(AssetId assetId) {
+    var source = sources[assetId];
+    return source != null && _isLibrary(source);
+  }
+
+  bool _isLibrary(Source source) =>
+      _context.computeKindOf(source) == SourceKind.LIBRARY;
+
+  @override
   LibraryElement getLibrary(AssetId assetId) {
     var source = sources[assetId];
     if (source == null) return null;
-    var kind = _context.computeKindOf(source);
-    if (kind != SourceKind.LIBRARY) return null;
+    if (!_isLibrary(source)) return null;
     return _context.computeLibraryElement(source);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_transformers
-version: 0.5.0+2
+version: 0.5.1
 author: Dart Team <misc@dartlang.org>
 description: Collection of utilities related to creating barback transformers.
 homepage: https://github.com/dart-lang/code-transformers


### PR DESCRIPTION
Behavior for trying to resolve a Library from a non-library source
remains the same - it will return null.